### PR TITLE
Support for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌈colorized-access-modifiers🌈
 
-VS Code Extension to highlight access modifiers(excluding Public) of Ruby 💎 Language.
+VS Code Extension to highlight access modifiers(excluding Public) of Ruby 💎 [b]PHP 🐘[/b] Language.
 
 ## 😎 Features
 
@@ -14,7 +14,9 @@ Highlight the Private and Protected access modifiers to easily find/identify the
 You can change the Text and Background Colors for both `private` and `protected` modifiers using following settings:
 
 - `colorized_access_modifier.privateBackground`: Background Color for Private
+- `colorized_access_modifier.privateBackgroundRuler`: Background Color for Private in the ruler
 - `colorized_access_modifier.protectedBackground`: Background Color for Protected
+- `colorized_access_modifier.protectedBackgroundRuler`: Background Color for Protected in the ruler
 - `colorized_access_modifier.privateText`: Text Color of Private
 - `colorized_access_modifier.protectedText`: Text Color of Protected
 
@@ -31,6 +33,10 @@ Initial release.
 ### 1.1.0
 
 Added support to colorize complete scope of each access modifier, on right of ruler lane.
+
+### 1.2.0
+
+Added support to work with PHP files and added the two new color values for the colors in the ruler.
 
 -----------------------------------------------------------------------------------------------------------
 ## Enjoy! 😃

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌈colorized-access-modifiers🌈
 
-VS Code Extension to highlight access modifiers(excluding Public) of Ruby 💎 [b]PHP 🐘[/b] Language.
+VS Code Extension to highlight access modifiers(excluding Public) of Ruby 💎 and PHP 🐘 Language.
 
 ## 😎 Features
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can change the Text and Background Colors for both `private` and `protected`
 - `colorized_access_modifier.privateText`: Text Color of Private
 - `colorized_access_modifier.protectedText`: Text Color of Protected
 
+Additionally, you can change the length of the colorization and the font weight
+- `colorized_access_modifier.colorizeFullLine`: True or false to make the full line in the color
+- `colorized_access_modifier.fontWeight`: Empty string or 'Bold' to change the font weight
+
 ## 😐 Known Issues
 
 None yet, but do let me know if you find any.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "colorized-access-modifier",
-	"version": "0.0.1",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Colorized Access Modifiers",
   "description": "Colorize the Access Modifiers to identify the code under them",
   "publisher": "GauravSharma",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.57.0"
   },
@@ -24,6 +24,23 @@
   "icon": "images/icon.png",
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration":[
+      {
+        "title": "Colorized Access Modifiers",
+        "properties": {
+          "colorized_access_modifier.colorizeFullLine": {
+            "type": "boolean",
+            "default": true,
+            "description": "Define if the color should be added to the full line or to the access modifier only."
+          },
+          "colorized_access_modifier.fontWeight": {
+            "type": "string",
+            "default": "bold",
+            "description": "Define the font weight for the access modifiers."
+          }
+        }
+      }
+    ],
     "colors": [
       {
         "id": "colorized_access_modifier.privateBackground",
@@ -34,7 +51,16 @@
           "highContrast": "#dda200e3"
         }
       },
-	  {
+      {
+        "id": "colorized_access_modifier.privateBackgroundRuler",
+        "description": "Background decoration color for Private in the ruler",
+        "defaults": {
+          "dark": "#ffbb0055",
+          "light": "#ffa600c0",
+          "highContrast": "#dda200e3"
+        }
+      },
+      {
         "id": "colorized_access_modifier.privateText",
         "description": "Text decoration color for Private",
         "defaults": {
@@ -52,7 +78,16 @@
           "highContrast": "#ff0000ab"
         }
       },
-	  {
+      {
+        "id": "colorized_access_modifier.protectedBackgroundRuler",
+        "description": "Background decoration color for Protected in the ruler",
+        "defaults": {
+          "dark": "#ff000055",
+          "light": "#ff3333bd",
+          "highContrast": "#ff0000ab"
+        }
+      },
+      {
         "id": "colorized_access_modifier.protectedText",
         "description": "Text decoration color for Protected",
         "defaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,9 @@ import * as vscode from 'vscode';
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 	let timeout: NodeJS.Timer | undefined = undefined;
+	const workbenchConfig = vscode.workspace.getConfiguration();
+	const fullLine = workbenchConfig.get('colorized_access_modifier.colorizeFullLine') as boolean;
+	const fontWeight = workbenchConfig.get('colorized_access_modifier.fontWeight') as string;
 
 	// create a decorator type that we use to decorate private
 	const privateDecorationType = vscode.window.createTextEditorDecorationType({
@@ -13,17 +16,12 @@ export function activate(context: vscode.ExtensionContext) {
 		overviewRulerLane: vscode.OverviewRulerLane.Full,
 		backgroundColor: { id: 'colorized_access_modifier.privateBackground' },
 		color: { id: 'colorized_access_modifier.privateText' },
-		fontWeight: 'bold',
-		isWholeLine: true
+		fontWeight: fontWeight,
+		isWholeLine: fullLine
 	});
 
 	const privateRulerLaneDecorationType = vscode.window.createTextEditorDecorationType({
-		overviewRulerColor: { id: 'colorized_access_modifier.privateBackground' },
-		overviewRulerLane: vscode.OverviewRulerLane.Right
-	});
-
-	const protectedRulerLaneDecorationType = vscode.window.createTextEditorDecorationType({
-		overviewRulerColor: { id: 'colorized_access_modifier.protectedBackground' },
+		overviewRulerColor: { id: 'colorized_access_modifier.privateBackgroundRuler' },
 		overviewRulerLane: vscode.OverviewRulerLane.Right
 	});
 
@@ -32,64 +30,134 @@ export function activate(context: vscode.ExtensionContext) {
 		overviewRulerLane: vscode.OverviewRulerLane.Full,
 		backgroundColor: { id: 'colorized_access_modifier.protectedBackground' },
 		color: { id: 'colorized_access_modifier.protectedText' },
-		fontWeight: 'bold',
-		isWholeLine: true
+		fontWeight: fontWeight,
+		isWholeLine: fullLine
+	});
+
+	const protectedRulerLaneDecorationType = vscode.window.createTextEditorDecorationType({
+		overviewRulerColor: { id: 'colorized_access_modifier.protectedBackgroundRuler' },
+		overviewRulerLane: vscode.OverviewRulerLane.Right
 	});
 
 	let activeEditor = vscode.window.activeTextEditor;
 	let isRuby = activeEditor?.document.languageId === 'ruby';
+	let isPhp = activeEditor?.document.languageId === 'php';
 
 	function updateDecorations() {
 		if (!activeEditor) {
 			return;
-		} else if(!isRuby) {
+		} else if(!isRuby && !isPhp) {
 			activeEditor.setDecorations(privateDecorationType, []);
 			activeEditor.setDecorations(privateRulerLaneDecorationType, []);
 			activeEditor.setDecorations(protectedDecorationType, []);
 			return;
 		}
-		const declarationRegex = /(^[^\S\r\n]*private$)|(^[^\S\r\n]*protected$)/gm;
-		const privateRulerRegex = /private(\r\n|\r|\n)+(((?!^end)(?!.*protected).+)(\r\n|\r|\n)+)*/gm;
-		const protectedRulerRegex = /protected(\r\n|\r|\n)+(((?!^end)(?!.*private).+)(\r\n|\r|\n)+)*/gm;
-		const text = activeEditor.document.getText();
 
-		const privatesMatches: vscode.DecorationOptions[] = [];
-		const privateRulerMatches: vscode.DecorationOptions[] = [];
-		const protectedMatches: vscode.DecorationOptions[] = [];
-		const protectedRulerMatches: vscode.DecorationOptions[] = [];
+		if (isRuby) {
+			const declarationRegex = /(^[^\S\r\n]*private$)|(^[^\S\r\n]*protected$)/gm;
+			const privateRulerRegex = /private(\r\n|\r|\n)+(((?!^end)(?!.*protected).+)(\r\n|\r|\n)+)*/gm;
+			const protectedRulerRegex = /protected(\r\n|\r|\n)+(((?!^end)(?!.*private).+)(\r\n|\r|\n)+)*/gm;
+			const text = activeEditor.document.getText();
 
-		let match;
-		while ((match = declarationRegex.exec(text))) {
-			const startPos = activeEditor.document.positionAt(match.index);
-			const endPos = activeEditor.document.positionAt(match.index + match[0].length);
-			const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+			const privatesMatches: vscode.DecorationOptions[] = [];
+			const privateRulerMatches: vscode.DecorationOptions[] = [];
+			const protectedMatches: vscode.DecorationOptions[] = [];
+			const protectedRulerMatches: vscode.DecorationOptions[] = [];
 
-			if(match[0].trim() === 'private') {
-				privatesMatches.push(decoration);
-			} else {
-				protectedMatches.push(decoration);
+			let match;
+			while ((match = declarationRegex.exec(text))) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+
+				if(match[0].trim() === 'private') {
+					privatesMatches.push(decoration);
+				} else {
+					protectedMatches.push(decoration);
+				}
 			}
-		}
 
-		
-		while ((match = privateRulerRegex.exec(text))) {
-			const startPos = activeEditor.document.positionAt(match.index);
-			const endPos = activeEditor.document.positionAt(match.index + match[0].length);
-			const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
-			privateRulerMatches.push(decoration);
-		}
+			
+			while ((match = privateRulerRegex.exec(text))) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+				privateRulerMatches.push(decoration);
+			}
 
-		while ((match = protectedRulerRegex.exec(text))) {
-			const startPos = activeEditor.document.positionAt(match.index);
-			const endPos = activeEditor.document.positionAt(match.index + match[0].length);
-			const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
-			protectedRulerMatches.push(decoration);
-		}
+			while ((match = protectedRulerRegex.exec(text))) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+				protectedRulerMatches.push(decoration);
+			}
 
-		activeEditor.setDecorations(privateDecorationType, privatesMatches);
-		activeEditor.setDecorations(privateRulerLaneDecorationType, privateRulerMatches);
-		activeEditor.setDecorations(protectedDecorationType, protectedMatches);
-		activeEditor.setDecorations(protectedRulerLaneDecorationType, protectedRulerMatches);
+			activeEditor.setDecorations(privateDecorationType, privatesMatches);
+			activeEditor.setDecorations(privateRulerLaneDecorationType, privateRulerMatches);
+			activeEditor.setDecorations(protectedDecorationType, protectedMatches);
+			activeEditor.setDecorations(protectedRulerLaneDecorationType, protectedRulerMatches);
+		} else if (isPhp) {
+			const declarationRegex = /([^\S\r\n]*private\s)|([^\S\r\n]*protected\s)/gm;
+			const privateRulerRegex = /([^\S\r\n]*private\s)/gm;
+			const protectedRulerRegex = /([^\S\r\n]*protected\s)/gm;
+			const text = activeEditor.document.getText();
+
+			const privatesMatches: vscode.DecorationOptions[] = [];
+			const privateRulerMatches: vscode.DecorationOptions[] = [];
+			const protectedMatches: vscode.DecorationOptions[] = [];
+			const protectedRulerMatches: vscode.DecorationOptions[] = [];
+
+			let match;
+			while ((match = declarationRegex.exec(text))) {
+				if (match.length < 0) {
+					continue;
+				}
+
+				const val = match[0];
+				if (val === null) {
+					continue;
+				}
+
+				const spacesBefore = val.match(/^\s*/);
+				let numberOfSpaceBefore = 0;
+				if (spacesBefore !== null && spacesBefore.length > 0) {
+					numberOfSpaceBefore = spacesBefore[0].length;
+				}
+				const spacesAfter = val.match(/\s*$/);
+				let numberOfSpacesAfter = 0;
+				if (spacesAfter !== null && spacesAfter.length > 0) {
+					numberOfSpacesAfter = spacesAfter[0].length;
+				}
+				const startPos = activeEditor.document.positionAt(match.index + numberOfSpaceBefore);
+				const endPos = activeEditor.document.positionAt(match.index + (match[0].length) - numberOfSpacesAfter);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+
+				if (match[0].trim() === 'private') {
+					privatesMatches.push(decoration);
+				} else {
+					protectedMatches.push(decoration);
+				}
+			}
+
+			while ((match = privateRulerRegex.exec(text))) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+				privateRulerMatches.push(decoration);
+			}
+
+			while ((match = protectedRulerRegex.exec(text))) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration:vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+				protectedRulerMatches.push(decoration);
+			}
+
+			activeEditor.setDecorations(privateDecorationType, privatesMatches);
+			activeEditor.setDecorations(privateRulerLaneDecorationType, privateRulerMatches);
+			activeEditor.setDecorations(protectedDecorationType, protectedMatches);
+			activeEditor.setDecorations(protectedRulerLaneDecorationType, protectedRulerMatches);
+		}
 	}
 
 	function triggerUpdateDecorations() {
@@ -97,10 +165,11 @@ export function activate(context: vscode.ExtensionContext) {
 			clearTimeout(timeout);
 			timeout = undefined;
 		}
+
 		timeout = setTimeout(updateDecorations, 500);
 	}
 
-	if (activeEditor && isRuby) {
+	if (activeEditor && (isRuby || isPhp)) {
 		triggerUpdateDecorations();
 	}
 
@@ -112,6 +181,8 @@ export function activate(context: vscode.ExtensionContext) {
 		
 		if (activeEditor) {
 			isRuby = activeEditor.document.languageId === 'ruby';
+			isPhp = activeEditor.document.languageId === 'php';
+
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);
@@ -119,23 +190,25 @@ export function activate(context: vscode.ExtensionContext) {
 	// Called when Language mode for the document is changed
 	// https://code.visualstudio.com/api/references/vscode-api#workspace
 	vscode.workspace.onDidOpenTextDocument(document => {
-		isRuby = document.languageId === 'ruby';
+		if (activeEditor) {
+			isRuby = activeEditor.document.languageId === 'ruby';
+			isPhp = activeEditor.document.languageId === 'php';
 
-		if(activeEditor) {
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);
 
 	vscode.workspace.onDidChangeTextDocument(event => {
-		isRuby = event.document.languageId === 'ruby';
-
 		if (activeEditor && event.document === activeEditor.document) {
+			isRuby = activeEditor.document.languageId === 'ruby';
+			isPhp = activeEditor.document.languageId === 'php';
+
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);
 
 	vscode.window.onDidChangeActiveColorTheme(theme => {
-		if(activeEditor) {
+		if (activeEditor) {
 			triggerUpdateDecorations();
 		}
 	}, null, context.subscriptions);


### PR DESCRIPTION
Hi guarav-12

I've switched to Visual Studio Code recently. Since i'm working with PHP most of the time, i adjusted my settings to fit my expectations but one piece was still missing - different colors for the access modifiers.

After searching for a solution, i found your extension in the extension list. But it is locked to Ruby - so i forked it and added the functionality for PHP.

Since in PHP the modifier is inline, i've also added some additional config values to modify the length of the colorization (full line yes/no) and the font weight of the text.

I also added two additional color values to manipulate the color in the ruler independetly from the background in the code since in my case, i only want the text color in the code (without a colorful background) and in the ruler a different one.

I haven't tested the Ruby part of the code but since i more or less didn't touch it i guess it should still work perfectly.

If i should change something. please tell me.

Thanks, 
zepi